### PR TITLE
Deprecation fix

### DIFF
--- a/vcf-input-mask-demo/pom.xml
+++ b/vcf-input-mask-demo/pom.xml
@@ -40,15 +40,7 @@
         <!-- Flow -->
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>flow-data</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>flow-html-components</artifactId>
+            <artifactId>vaadin-core</artifactId>
         </dependency>
 
         <!-- Component -->

--- a/vcf-input-mask-demo/src/main/java/com/vaadin/componentfactory/demo/InputMaskDemoView.java
+++ b/vcf-input-mask-demo/src/main/java/com/vaadin/componentfactory/demo/InputMaskDemoView.java
@@ -18,6 +18,7 @@ package com.vaadin.componentfactory.demo;
 import static com.vaadin.componentfactory.addons.inputmask.InputMaskOption.option;
 
 import com.vaadin.componentfactory.addons.inputmask.InputMask;
+import com.vaadin.componentfactory.addons.inputmask.InputMaskOption;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.datepicker.DatePicker;
@@ -28,11 +29,13 @@ import com.vaadin.flow.component.grid.editor.Editor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.ValidationResult;
 import com.vaadin.flow.data.binder.ValueContext;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 import java.util.Arrays;
 import java.util.List;
@@ -52,8 +55,39 @@ public class InputMaskDemoView extends VerticalLayout {
 		createBasicInputMaskOnDatePickerDemo();
 		createInputMaskOnTextFieldWithBinderDemo();
 		createInputMaskOnTextFielOnGridCellDemo();
+		createNumberInputMaskOnTextFieldDemo();
 	}
 
+	private void createNumberInputMaskOnTextFieldDemo() {
+		Div message = createMessageDiv("number-input-mask-on-text-field-demo-message");
+		Span maskedValueSpan = new Span();
+		Span unmaskedValueSpan = new Span();
+
+		TextField numberField = new TextField("Number");
+		InputMask inputMask = new InputMask("Number", true,
+				InputMaskOption.option("scale", 2),
+				InputMaskOption.option("thousandsSeparator", "-"),
+				InputMaskOption.option("radix", '.')
+		);
+
+		inputMask
+				.extend(numberField);
+		numberField.setValueChangeMode(ValueChangeMode.ON_BLUR);
+
+		numberField.addValueChangeListener(ev -> {
+			inputMask.getMaskedValue(masked -> {
+				maskedValueSpan.setText("Masked value: " + masked);
+			});
+			inputMask.getUnmaskedValue(unmasked -> {
+				unmaskedValueSpan.setText(" - Unmasked value: " + unmasked);
+			});
+			message.add(maskedValueSpan, unmaskedValueSpan);
+		});
+
+		numberField.setId("number-input-mask-on-text-field");
+
+		add(createCard("Simple input mask on text field", numberField, message));
+	}
 	private void createBasicInputMaskOnTextFieldDemo() {
 		Div message = createMessageDiv("simple-input-mask-on-text-field-demo-message");
 		Span maskedValueSpan = new Span();

--- a/vcf-input-mask-demo/src/main/java/com/vaadin/componentfactory/demo/InputMaskDemoView.java
+++ b/vcf-input-mask-demo/src/main/java/com/vaadin/componentfactory/demo/InputMaskDemoView.java
@@ -56,6 +56,7 @@ public class InputMaskDemoView extends VerticalLayout {
 		createInputMaskOnTextFieldWithBinderDemo();
 		createInputMaskOnTextFielOnGridCellDemo();
 		createNumberInputMaskOnTextFieldDemo();
+		createRegExpInputMaskOnTextFieldDemo();
 	}
 
 	private void createNumberInputMaskOnTextFieldDemo() {
@@ -86,8 +87,34 @@ public class InputMaskDemoView extends VerticalLayout {
 
 		numberField.setId("number-input-mask-on-text-field");
 
-		add(createCard("Simple input mask on text field", numberField, message));
+		add(createCard("Simple number mask on text field", numberField, message));
 	}
+
+	private void createRegExpInputMaskOnTextFieldDemo() {
+		Div message = createMessageDiv("regexp-input-mask-on-text-field-demo-message");
+		Span maskedValueSpan = new Span();
+		Span unmaskedValueSpan = new Span();
+
+		TextField numberField = new TextField("Regexp digits");
+		InputMask inputMask = new InputMask("/^\\d+$/", true);
+
+		inputMask.extend(numberField);
+
+		numberField.addValueChangeListener(ev -> {
+			inputMask.getMaskedValue(masked -> {
+				maskedValueSpan.setText("Masked value: " + masked);
+			});
+			inputMask.getUnmaskedValue(unmasked -> {
+				unmaskedValueSpan.setText(" - Unmasked value: " + unmasked);
+			});
+			message.add(maskedValueSpan, unmaskedValueSpan);
+		});
+
+		numberField.setId("regexp-input-mask-on-text-field");
+
+		add(createCard("Simple regexp input mask on text field", numberField, message));
+	}
+
 	private void createBasicInputMaskOnTextFieldDemo() {
 		Div message = createMessageDiv("simple-input-mask-on-text-field-demo-message");
 		Span maskedValueSpan = new Span();

--- a/vcf-input-mask/pom.xml
+++ b/vcf-input-mask/pom.xml
@@ -40,6 +40,7 @@
          <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-core</artifactId>
+             <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/vcf-input-mask/src/main/java/com/vaadin/componentfactory/addons/inputmask/InputMask.java
+++ b/vcf-input-mask/src/main/java/com/vaadin/componentfactory/addons/inputmask/InputMask.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Tag("input-mask")
-@NpmPackage(value = "imask", version = "6.5.0")
+@NpmPackage(value = "imask", version = "7.1.3")
 @JsModule("./src/input-mask.js")
 public class InputMask extends Component {
 

--- a/vcf-input-mask/src/main/resources/META-INF/resources/frontend/src/input-mask.js
+++ b/vcf-input-mask/src/main/resources/META-INF/resources/frontend/src/input-mask.js
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-import { LitElement } from 'lit-element';
+import { LitElement } from 'lit';
 import IMask from 'imask';
 
 /**
@@ -41,7 +41,7 @@ class InputMask extends LitElement {
         let el = this.parentElement.querySelector('input');
         this.imask = new IMask(el, this._generateIMaskOptions(JSON.parse(this.options)));
       }  
-      this.parentElement.addEventListener("keydown", e => this._handleKeyEvent(e));    
+      this.parentElement.addEventListener("keydown", e => this._handleKeyEvent(e));
     }
   }
 


### PR DESCRIPTION
- Add a demo for number.
- Add the scope provided for the Vaadin dependencies
- Bump the version of imask to the latest
- Update the import of lit-element (deprecated) to lit
- Fix the pom of the demo and add an example of Regexp