### PR TITLE
Fix server value issue

### DIFF
--- a/vcf-input-mask/src/main/java/com/vaadin/componentfactory/addons/inputmask/InputMask.java
+++ b/vcf-input-mask/src/main/java/com/vaadin/componentfactory/addons/inputmask/InputMask.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.shared.Registration;
 import java.lang.ref.WeakReference;
@@ -74,7 +75,13 @@ public class InputMask extends Component {
             getElement().setProperty("options", objectMapper.writeValueAsString(options));
 
             extended = new WeakReference<Component>(component);
-            component.getElement().appendChild(getElement());
+            
+            Element componentElement = component.getElement();
+            // remove any existing input-mask element attached to component
+            componentElement.getChildren()
+                    .filter(child -> TAG_NAME.equalsIgnoreCase(child.getTag()))
+                    .findAny().ifPresent(componentElement::removeChild);
+            componentElement.appendChild(getElement());
             
             if (HasValue.class.isAssignableFrom(component.getClass())) {
                 valueChangeRegistration = HasValue.class.cast(component).addValueChangeListener(e -> {

--- a/vcf-input-mask/src/main/resources/META-INF/resources/frontend/src/input-mask.js
+++ b/vcf-input-mask/src/main/resources/META-INF/resources/frontend/src/input-mask.js
@@ -121,7 +121,10 @@ class InputMask extends LitElement {
   getMaskedValue() {
     return this.imask ? this.imask.value : "";
   }
-  
+ 
+  setValue(value){
+    this.imask.value = value;
+  }
 }
 
 window.customElements.define(InputMask.is, InputMask);


### PR DESCRIPTION
Issues fixed:

- Extending same component multiple times adds several input-mask children elements to parent's DOM. There should be only one input-mask child.
- When updating extended field value from server side, iMask instance value in client side stays out on sync. This causes that, when clearing field's value from server side, if user starts typing in the field, previously entered chars are appended to the entered text.