### PR TITLE
fix: regression bug when synchronizing server value

### DIFF
--- a/vcf-input-mask/src/main/java/com/vaadin/componentfactory/addons/inputmask/InputMask.java
+++ b/vcf-input-mask/src/main/java/com/vaadin/componentfactory/addons/inputmask/InputMask.java
@@ -86,8 +86,11 @@ public class InputMask extends Component {
             if (HasValue.class.isAssignableFrom(component.getClass())) {
                 valueChangeRegistration = HasValue.class.cast(component).addValueChangeListener(e -> {
                     if (!e.isFromClient()) {
-                        getElement().executeJs("this.setValue($0)",
-                                e.getValue() == null ? "" : e.getValue().toString());
+                        if (e.getValue() == null) {
+                            getElement().executeJs("this.setValue('')");
+                        } else {
+                            getElement().executeJs("this.setValue($0.inputElement.value)", component.getElement());
+                        }
                     }
                 });
             }


### PR DESCRIPTION
Synchronizing server value for date and numeric fields don't work. Instead of using value's toString(), plain text value from client element should be used to avoid any value formatting issues.