### PR TITLE
Fix iMask instance value synchronization with server

### DIFF
--- a/vcf-input-mask/src/main/java/com/vaadin/componentfactory/addons/inputmask/InputMask.java
+++ b/vcf-input-mask/src/main/java/com/vaadin/componentfactory/addons/inputmask/InputMask.java
@@ -86,11 +86,8 @@ public class InputMask extends Component {
             if (HasValue.class.isAssignableFrom(component.getClass())) {
                 valueChangeRegistration = HasValue.class.cast(component).addValueChangeListener(e -> {
                     if (!e.isFromClient()) {
-                        if (e.getValue() == null) {
-                            getElement().executeJs("this.setValue('')");
-                        } else {
-                            getElement().executeJs("this.setValue($0.inputElement.value)", component.getElement());
-                        }
+                        getElement().executeJs("this.setValue($0.inputElement ? $0.inputElement.value : '')",
+                                component.getElement());
                     }
                 });
             }


### PR DESCRIPTION
When using binder or setting masked field's value from server side, iMask instance value on client side doesn't reflect server value.