### PR TITLE
refactor: replace direct eval with new Function

### DIFF
--- a/vcf-input-mask/src/main/resources/META-INF/frontend/src/input-mask.js
+++ b/vcf-input-mask/src/main/resources/META-INF/frontend/src/input-mask.js
@@ -211,7 +211,10 @@ class InputMask extends LitElement {
     const result = {};
     maskOptions.forEach(opt => {
         if (opt.eval) {
-          eval(`result.${opt.key} = ${opt.value}`);
+          // `new Function` instead of a direct `eval`, which bundlers flag because it
+          // disables scope minification. `IMask` is passed in explicitly: the body is
+          // compiled in global scope and would not see the module-level import.
+          result[opt.key] = new Function('IMask', `"use strict"; return (${opt.value});`)(IMask);
         } else if (opt.key === 'blocks') {
           const blocks = {};
           opt.value.forEach(block => blocks[block.key] = this._parseBlock(block.value));
@@ -227,7 +230,7 @@ class InputMask extends LitElement {
     const result = {};
     block.forEach(item => {
         if (item.eval) {
-          eval(`result.${item.key} = ${item.value}`);
+          result[item.key] = new Function('IMask', `"use strict"; return (${item.value});`)(IMask);
         } else {
           result[item.key] = item.value;
         }


### PR DESCRIPTION
Direct `eval` makes bundlers skip scope minification, so rolldown reports it as an `[EVAL]` warning on every dev bundle build with Vaadin 25.2+. `new Function` does the same job without the warning: only the option value is evaluated, and the assignment to `result` is done from JS. `IMask` is passed in as an argument because the function body is compiled in global scope and would not otherwise see the module-level import.

_Note: this fix was implemented together with ClaudeCode. AI generated code was manually reviewed by the author._

Close #22