### PR TITLE
Fix missing value change events for full-field pastes on eager masks

### DIFF
--- a/vcf-input-mask-demo/pom.xml
+++ b/vcf-input-mask-demo/pom.xml
@@ -9,7 +9,7 @@
     <packaging>war</packaging>
     <name>Input Maks Add-on Demo</name>
 
-    <version>3.1.3-SNAPSHOTs</version>
+    <version>3.1.3-SNAPSHOT</version>
     <inceptionYear>2023</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>

--- a/vcf-input-mask-demo/src/main/java/com/vaadin/componentfactory/demo/EmbeddedConstantMaskDemoView.java
+++ b/vcf-input-mask-demo/src/main/java/com/vaadin/componentfactory/demo/EmbeddedConstantMaskDemoView.java
@@ -19,6 +19,7 @@ import com.vaadin.componentfactory.addons.inputmask.InputMask;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -51,6 +52,39 @@ public class EmbeddedConstantMaskDemoView extends BaseDemoView {
     addClassName("demo-view");
     createLegacyStyleMaskDemo();
     createLazyMaskDemo();
+    createEagerValueChangeModeDemo();
+  }
+
+  /**
+   * Same eager mask as the first card, but with {@link ValueChangeMode#EAGER}
+   * and both a value change and a blur listener, mirroring applications whose
+   * business logic requires the value change event to arrive before the blur
+   * event. The message logs the server-side event sequence, which makes it
+   * visible when an edit (e.g. a paste) does not produce a value change.
+   */
+  private void createEagerValueChangeModeDemo() {
+    Div message = createMessageDiv("embedded-constant-mask-eager-vcm-demo-message");
+    StringBuilder eventLog = new StringBuilder();
+
+    TextField eagerField = new TextField("Legacy code (EAGER value change mode)");
+    eagerField.setWidth("400px");
+    eagerField.setValueChangeMode(ValueChangeMode.EAGER);
+    InputMask inputMask = new InputMask(EMBEDDED_CONSTANT_MASK, lazy(false),
+        option("placeholderChar", " "), option("eager", true));
+    inputMask.extend(eagerField);
+
+    eagerField.addValueChangeListener(ev -> {
+      eventLog.append("[value-change: ").append(ev.getValue()).append(']');
+      message.setText(eventLog.toString());
+    });
+    eagerField.addBlurListener(ev -> {
+      eventLog.append("[blur]");
+      message.setText(eventLog.toString());
+    });
+
+    eagerField.setId("embedded-constant-mask-eager-vcm-text-field");
+
+    add(createCard("Eager mask with EAGER value change mode", eagerField, message));
   }
 
   private void createLegacyStyleMaskDemo() {

--- a/vcf-input-mask-demo/src/test/java/com/vaadin/componentfactory/demo/EmbeddedConstantMaskPlaywrightIT.java
+++ b/vcf-input-mask-demo/src/test/java/com/vaadin/componentfactory/demo/EmbeddedConstantMaskPlaywrightIT.java
@@ -58,6 +58,13 @@ public class EmbeddedConstantMaskPlaywrightIT extends AbstractPlaywrightTest {
   private static final String LAZY_MESSAGE_SELECTOR =
       "#embedded-constant-mask-lazy-demo-message";
 
+  private static final String EAGER_VCM_FIELD_INPUT_SELECTOR =
+      "vaadin-text-field#embedded-constant-mask-eager-vcm-text-field input";
+  private static final String EAGER_VCM_INPUT_MASK_SELECTOR =
+      "vaadin-text-field#embedded-constant-mask-eager-vcm-text-field input-mask";
+  private static final String EAGER_VCM_MESSAGE_SELECTOR =
+      "#embedded-constant-mask-eager-vcm-demo-message";
+
   // Mask template rendered by lazy=false + placeholderChar " ":
   // one blank slot, constant "08000-", then hyphen-separated slot groups.
   private static final String EMPTY_TEMPLATE = " 08000-  -  -      - ";
@@ -168,6 +175,30 @@ public class EmbeddedConstantMaskPlaywrightIT extends AbstractPlaywrightTest {
   }
 
   @Test
+  public void pastingIntoEagerValueChangeModeFieldFiresValueChangeBeforeBlur() {
+    openDemo();
+
+    Locator input = page.locator(EAGER_VCM_FIELD_INPUT_SELECTOR);
+    input.click();
+    paste(FORMATTED_VALUE);
+    assertThat(input).hasValue(FORMATTED_VALUE);
+
+    // ValueChangeMode.EAGER synchronizes on the input event, so the value
+    // change event must reach the server without any blur. The wrapper
+    // replays the input event after applying the pasted value; without that,
+    // the prevented paste produces no input event and the server never
+    // receives a value change (the regression behind this test).
+    Locator message = page.locator(EAGER_VCM_MESSAGE_SELECTOR);
+    assertThat(message).hasText("[value-change: " + FORMATTED_VALUE + "]");
+
+    // Blurring afterwards must append the blur event after the value change,
+    // the ordering that applications combining value change and blur
+    // listeners rely on.
+    input.press("Tab");
+    assertThat(message).hasText("[value-change: " + FORMATTED_VALUE + "][blur]");
+  }
+
+  @Test
   public void pastingFormattedValueIntoNonEagerFieldUsesDefaultHandling() {
     openDemo();
 
@@ -186,6 +217,8 @@ public class EmbeddedConstantMaskPlaywrightIT extends AbstractPlaywrightTest {
     page.locator(LEGACY_INPUT_MASK_SELECTOR).waitFor(
         new Locator.WaitForOptions().setState(WaitForSelectorState.ATTACHED));
     page.locator(LAZY_INPUT_MASK_SELECTOR).waitFor(
+        new Locator.WaitForOptions().setState(WaitForSelectorState.ATTACHED));
+    page.locator(EAGER_VCM_INPUT_MASK_SELECTOR).waitFor(
         new Locator.WaitForOptions().setState(WaitForSelectorState.ATTACHED));
   }
 

--- a/vcf-input-mask/src/main/resources/META-INF/frontend/src/input-mask.js
+++ b/vcf-input-mask/src/main/resources/META-INF/frontend/src/input-mask.js
@@ -225,11 +225,17 @@ class InputMask extends LitElement {
 	}
 	ev.preventDefault();
 	this.imask.value = text;
-	const caret = masked.nearestInputPos(masked.displayValue.length, 'LEFT');
-	input.setSelectionRange(caret, caret);
-	// Reuse the regular change flow (imask commit + host field sync). The
-	// prevented paste never marks the input dirty, so without this the host
-	// field would not pick up the pasted value on blur.
+	// Position the caret through IMask so its saved selection matches: its
+	// own `input` listener then treats the synthetic event below as a no-op
+	// instead of re-processing the pasted value as raw input.
+	this.imask.cursorPos = masked.nearestInputPos(masked.displayValue.length, 'LEFT');
+	// The prevented paste produces no native events, so replay the regular
+	// event sequence: `input` drives the input-based value change modes
+	// (EAGER / LAZY / TIMEOUT), `change` the commit flow (imask commit + host
+	// field sync). Without the latter the host field would not pick up the
+	// pasted value on blur, as the input was never marked dirty.
+	input.dispatchEvent(new InputEvent('input',
+	    { bubbles: true, composed: true, inputType: 'insertFromPaste', data: text }));
 	input.dispatchEvent(new Event('change', { bubbles: true }));
   }
 


### PR DESCRIPTION
## Summary

This fixes #30

The eager-paste handling introduced in 3.1.2 prevents the paste's default
action, so no native `input` event fires. Value change modes that synchronize
on the `input` event (`EAGER`, `LAZY`, `TIMEOUT`) therefore never delivered a
`ValueChangeEvent` for such a paste: the field displayed the pasted value, but
application listeners — e.g. business logic expecting a value change before
the blur event — never ran. Typing, `ON_CHANGE` and `ON_BLUR` were unaffected.

**Target branch:** `v25`. The fix is confined to the `input-mask.js`
connector — no public Java API changes.

## Fix

After applying the pasted value, the connector now replays the regular event
sequence: an `input` event (`inputType: 'insertFromPaste'`), which drives the
input-based value change modes, followed by the existing `change` event (the
commit flow). The caret is positioned through IMask's `cursorPos` instead of
`setSelectionRange`, so IMask's saved selection matches and its own `input`
listener treats the replayed event as a no-op instead of re-processing the
pasted value as raw input (which would re-introduce the slot-shifting bug
fixed in 3.1.2).

Also includes a one-line fix for the version typo `3.1.3-SNAPSHOTs` in the
demo pom, which broke dependency resolution of the add-on on `v25`.

## Testing

* New demo card on `/embedded-constant-mask`: the same eager mask with
  `ValueChangeMode.EAGER` and both a value change and a blur listener,
  logging the server-side event sequence.
* New Playwright test pasting into it via real clipboard paste (Ctrl/Cmd+V),
  asserting the value change event arrives without any blur and precedes the
  blur event.
* All 19 Playwright ITs and 9 unit tests pass via `mvn verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
